### PR TITLE
Replace use of each with foreach and fix PHPUnit tests

### DIFF
--- a/XML/RPC2/Backend/Php/Value/Datetime.php
+++ b/XML/RPC2/Backend/Php/Value/Datetime.php
@@ -146,7 +146,7 @@ class XML_RPC2_Backend_Php_Value_Datetime extends XML_RPC2_Backend_Php_Value
      */
     private static function _timestampToIso8601($timestamp)
     {
-        return strftime('%Y%m%dT%H:%M:%S', (int) $timestamp);
+        return date("Ymd\TH:i:s", (int) $timestamp);
     }
 
     /**

--- a/XML/RPC2/Backend/Xmlrpcext/Value.php
+++ b/XML/RPC2/Backend/Xmlrpcext/Value.php
@@ -65,7 +65,7 @@ class XML_RPC2_Backend_Xmlrpcext_Value
                 // is some cases (structs with numeric indexes), we need to be able to force the "struct" type
                 // (xmlrpc_set_type doesn't help for this, so we need this ugly hack)
                 $new = array();
-                while (list($k, $v) = each($value)) {
+                foreach ($value as $k => $v) {
                     $new["xml_rpc2_ugly_struct_hack_$k"] = $v;
                     // with this "string" prefix, we are sure that the array will be seen as a "struct"
                 }

--- a/XML/RPC2/Server/Method.php
+++ b/XML/RPC2/Server/Method.php
@@ -273,7 +273,7 @@ class XML_RPC2_Server_Method
         $result  .= "<span class=\"other\">(</span>";
         $first = true;
         $nbr = 0;
-        while (list($name, $parameter) = each($this->_parameters)) {
+        foreach ($this->_parameters as $name => $parameter) {
             $nbr++;
             if ($nbr == $this->_numberOfRequiredParameters + 1) {
                 $result .= "<span class=\"other\"> [ </span>";
@@ -316,7 +316,7 @@ class XML_RPC2_Server_Method
             if (count($this->_parameters)>0) {
                 print "      <table>\n";
                 print "        <tr><td><b>Type</b></td><td><b>Name</b></td><td><b>Documentation</b></td></tr>\n";
-                while (list($name, $parameter) = each($this->_parameters)) {
+                foreach ($this->_parameters as $name => $parameter) {
                     $type = $parameter['type'];
                     $doc = isset($parameter['doc']) ? htmlentities($parameter['doc']) : 'Method is not documented. No PHPDoc block was found associated with the method in the source code.';
                     print "        <tr><td>$type</td><td>$name</td><td>$doc</td></tr>\n";
@@ -338,25 +338,25 @@ class XML_RPC2_Server_Method
     {
         $tmp = mb_strtolower($type);
         $convertArray = array(
-            'int' => 'integer',
-            'i4' => 'integer',
-            'integer' => 'integer',
-            'string' => 'string',
-            'str' => 'string',
-            'char' => 'string',
-            'bool' => 'boolean',
-            'boolean' => 'boolean',
-            'array' => 'array',
-            'float' => 'double',
-            'double' => 'double',
-            'array' => 'array',
-            'struct' => 'array',
-            'assoc' => 'array',
-            'structure' => 'array',
-            'datetime' => 'mixed',
-            'datetime.iso8601' => 'mixed',
-            'iso8601' => 'mixed',
-            'base64' => 'string'
+        'int' => 'integer',
+        'i4' => 'integer',
+        'integer' => 'integer',
+        'string' => 'string',
+        'str' => 'string',
+        'char' => 'string',
+        'bool' => 'boolean',
+        'boolean' => 'boolean',
+        'array' => 'array',
+        'float' => 'double',
+        'double' => 'double',
+        'array' => 'array',
+        'struct' => 'array',
+        'assoc' => 'array',
+        'structure' => 'array',
+        'datetime' => 'mixed',
+        'datetime.iso8601' => 'mixed',
+        'iso8601' => 'mixed',
+        'base64' => 'string'
         );
         if (isset($convertArray[$tmp])) {
             return $convertArray[$tmp];

--- a/XML/RPC2/Server/Method.php
+++ b/XML/RPC2/Server/Method.php
@@ -304,7 +304,7 @@ class XML_RPC2_Server_Method
         $name = $this->getName();
         $signature = $this->getHTMLSignature();
         $id = md5($name);
-        $help = nl2br(htmlentities($this->_help));
+        $help = nl2br(htmlentities($this->_help, ENT_COMPAT));
         print "      <h3><a name=\"$id\">$signature</a></h3>\n";
         print "      <p><b>Description :</b></p>\n";
         print "      <div class=\"description\">\n";
@@ -317,7 +317,7 @@ class XML_RPC2_Server_Method
                 print "        <tr><td><b>Type</b></td><td><b>Name</b></td><td><b>Documentation</b></td></tr>\n";
                 foreach ($this->_parameters as $name => $parameter) {
                     $type = $parameter['type'];
-                    $doc = isset($parameter['doc']) ? htmlentities($parameter['doc']) : 'Method is not documented. No PHPDoc block was found associated with the method in the source code.';
+                    $doc = isset($parameter['doc']) ? htmlentities($parameter['doc'], ENT_COMPAT) : 'Method is not documented. No PHPDoc block was found associated with the method in the source code.';
                     print "        <tr><td>$type</td><td>$name</td><td>$doc</td></tr>\n";
                 }
                 print "      </table>\n";

--- a/XML/RPC2/Server/Method.php
+++ b/XML/RPC2/Server/Method.php
@@ -287,7 +287,6 @@ class XML_RPC2_Server_Method
             $result .= "<span class=\"paratype\">($type) </span>";
             $result .= "<span class=\"paraname\">$name</span>";
         }
-        reset($this->_parameters);
         if ($nbr > $this->_numberOfRequiredParameters) {
             $result .= "<span class=\"other\"> ] </span>";
         }
@@ -321,7 +320,6 @@ class XML_RPC2_Server_Method
                     $doc = isset($parameter['doc']) ? htmlentities($parameter['doc']) : 'Method is not documented. No PHPDoc block was found associated with the method in the source code.';
                     print "        <tr><td>$type</td><td>$name</td><td>$doc</td></tr>\n";
                 }
-                reset($this->_parameters);
                 print "      </table>\n";
             }
         }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,7 @@
 <phpunit bootstrap="vendor/autoload.php">
+  <php>
+    <ini name="xdebug.overload_var_dump" value="off"/>
+  </php>
   <testsuites>
     <testsuite name="phpBackend.cachedClient">
       <directory suffix=".phpt">tests/phpBackend/cachedClient</directory>

--- a/tests/phpBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOffByDefault1.phpt
+++ b/tests/phpBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOffByDefault1.phpt
@@ -22,7 +22,7 @@ $options = array(
     'cacheDebug' => true
 );
 
-$client = XML_RPC2_CachedClient::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_CachedClient::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $arg = array(
     'moe' => 5,
     'larry' => 6,

--- a/tests/phpBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOffByDefault2.phpt
+++ b/tests/phpBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOffByDefault2.phpt
@@ -23,7 +23,7 @@ $options = array(
     'cacheDebug' => true
 );
 
-$client = XML_RPC2_CachedClient::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_CachedClient::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $arg = array(
     'moe' => 5,
     'larry' => 6,

--- a/tests/phpBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOnByDefault1.phpt
+++ b/tests/phpBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOnByDefault1.phpt
@@ -22,7 +22,7 @@ $options = array(
     'cacheDebug' => true
 );
 
-$client = XML_RPC2_CachedClient::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_CachedClient::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $arg = array(
     'moe' => 5,
     'larry' => 6,

--- a/tests/phpBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOnByDefault2.phpt
+++ b/tests/phpBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOnByDefault2.phpt
@@ -23,7 +23,7 @@ $options = array(
     'cacheDebug' => true
 );
 
-$client = XML_RPC2_CachedClient::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_CachedClient::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $arg = array(
     'moe' => 5,
     'larry' => 6,

--- a/tests/phpBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOnByDefault3.phpt
+++ b/tests/phpBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOnByDefault3.phpt
@@ -27,7 +27,7 @@ $options = array(
     'cacheDebug' => true
 );
 
-$client = XML_RPC2_CachedClient::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_CachedClient::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $arg = array(
     'moe' => 5,
     'larry' => 6,

--- a/tests/phpBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOnByDefault4.phpt
+++ b/tests/phpBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOnByDefault4.phpt
@@ -28,7 +28,7 @@ $options = array(
     'cacheDebug' => true
 );
 
-$client = XML_RPC2_CachedClient::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_CachedClient::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $arg = array(
     'moe' => 5,
     'larry' => 6,

--- a/tests/phpBackend/client/phpxmlrpcValidator1ArrayOfStructsTest.phpt
+++ b/tests/phpBackend/client/phpxmlrpcValidator1ArrayOfStructsTest.phpt
@@ -16,7 +16,7 @@ $options = array(
     'backend' => 'Php',
     'prefix' => 'validator1.'
 );
-$client = XML_RPC2_Client::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_Client::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $arg = array(
     array(
         'moe' => 5,

--- a/tests/phpBackend/client/phpxmlrpcValidator1CountTheEntities.phpt
+++ b/tests/phpBackend/client/phpxmlrpcValidator1CountTheEntities.phpt
@@ -16,7 +16,7 @@ $options = array(
     'backend' => 'Php',
     'prefix' => 'validator1.'
 );
-$client = XML_RPC2_Client::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_Client::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $string = "foo <<< bar '> && '' #fo>o \" bar";
 $result = $client->countTheEntities($string);
 var_dump($result['ctLeftAngleBrackets']);

--- a/tests/phpBackend/client/phpxmlrpcValidator1EasyStructTest.phpt
+++ b/tests/phpBackend/client/phpxmlrpcValidator1EasyStructTest.phpt
@@ -16,7 +16,7 @@ $options = array(
     'backend' => 'Php',
     'prefix' => 'validator1.'
 );
-$client = XML_RPC2_Client::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_Client::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $arg = array(
     'moe' => 5,
     'larry' => 6,

--- a/tests/phpBackend/client/phpxmlrpcValidator1EchoStructTest.phpt
+++ b/tests/phpBackend/client/phpxmlrpcValidator1EchoStructTest.phpt
@@ -16,7 +16,7 @@ $options = array(
     'backend' => 'Php',
     'prefix' => 'validator1.'
 );
-$client = XML_RPC2_Client::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_Client::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $arg = array(
     'moe' => 5,
     'larry' => 6,

--- a/tests/phpBackend/client/phpxmlrpcValidator1ManyTypesTest.phpt
+++ b/tests/phpBackend/client/phpxmlrpcValidator1ManyTypesTest.phpt
@@ -18,7 +18,7 @@ $options = array(
     'backend' => 'Php',
     'prefix' => 'validator1.'
 );
-$client = XML_RPC2_Client::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_Client::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $tmp = "20060116T19:14:03";
 $time = XML_RPC2_Value::createFromNative($tmp, 'datetime');
 $base64 = XML_RPC2_Value::createFromNative('foobar', 'base64');

--- a/tests/phpBackend/client/phpxmlrpcValidator1ModerateSizeArrayCheck.phpt
+++ b/tests/phpBackend/client/phpxmlrpcValidator1ModerateSizeArrayCheck.phpt
@@ -16,7 +16,7 @@ $options = array(
     'backend' => 'Php',
     'prefix' => 'validator1.'
 );
-$client = XML_RPC2_Client::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_Client::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $tmp = array('foo');
 for ($i = 0 ; $i<150 ; $i++) {
     $tmp[] = "bla bla bla";

--- a/tests/phpBackend/client/phpxmlrpcValidator1NestedStructTest.phpt
+++ b/tests/phpBackend/client/phpxmlrpcValidator1NestedStructTest.phpt
@@ -16,7 +16,7 @@ $options = array(
     'backend' => 'Php',
     'prefix' => 'validator1.'
 );
-$client = XML_RPC2_Client::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_Client::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 
 $year1999 = array(
   '04' => array()

--- a/tests/phpBackend/client/phpxmlrpcValidator1SimpleStructReturnTest.phpt
+++ b/tests/phpBackend/client/phpxmlrpcValidator1SimpleStructReturnTest.phpt
@@ -16,7 +16,7 @@ $options = array(
     'backend' => 'Php',
     'prefix' => 'validator1.'
 );
-$client = XML_RPC2_Client::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_Client::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $result = $client->simpleStructReturnTest(13);
 var_dump($result['times10']);
 var_dump($result['times100']);

--- a/tests/phpBackend/regressions/11135.phpt
+++ b/tests/phpBackend/regressions/11135.phpt
@@ -24,4 +24,5 @@ $errcontext)
 }
 
 ?>
---EXPECT--
+--EXPECTREGEX--
+^$

--- a/tests/phpBackend/server/validator1ArrayOfStructsTest.phpt
+++ b/tests/phpBackend/server/validator1ArrayOfStructsTest.phpt
@@ -16,7 +16,7 @@ class TestServer {
      */
     public static function arrayOfStructsTest($array) {
         $result = 0;
-        foreach($array as $struct) {
+        foreach ($array as $struct) {
             if (isset($struct['curly'])) {
                 $result = $result + $struct['curly'];
             }

--- a/tests/phpBackend/server/validator1ArrayOfStructsTest.phpt
+++ b/tests/phpBackend/server/validator1ArrayOfStructsTest.phpt
@@ -16,7 +16,7 @@ class TestServer {
      */
     public static function arrayOfStructsTest($array) {
         $result = 0;
-        while (list(, $struct) = each($array)) {
+        foreach($array as $struct) {
             if (isset($struct['curly'])) {
                 $result = $result + $struct['curly'];
             }

--- a/tests/phpBackend/server/validator1NestedStructTest.phpt
+++ b/tests/phpBackend/server/validator1NestedStructTest.phpt
@@ -17,11 +17,11 @@ class TestServer {
     public static function nestedStructTest($struct) {
         // just to avoir problems with numeric indexes...
         $struct2 = array();
-        while (list($key, $year) = each($struct)) {
+        foreach ($struct as $key => $year) {
             if ($key=='2000') {
-                while (list($key2, $month) = each($year)) {
+                foreach ($year as $key2 => $month) {
                     if ($key2=='04') {
-                        while (list($key3, $day) = each($month)) {
+                        foreach ($month as $key3 => $day) {
                             if ($key3=='01') {
                                 return $day['moe'] + $day['larry'] + $day['curly'];
                             }

--- a/tests/regressions/14038.phpt
+++ b/tests/regressions/14038.phpt
@@ -22,4 +22,5 @@ $errcontext)
     $array_class = new Empty_Array_Value_Test();
     $array_class->createFromNative(array());
 }
---EXPECT--
+--EXPECTREGEX--
+^$

--- a/tests/xmlrpcextBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOffByDefault1.phpt
+++ b/tests/xmlrpcextBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOffByDefault1.phpt
@@ -26,7 +26,7 @@ $options = array(
     'cacheDebug' => true
 );
 
-$client = XML_RPC2_CachedClient::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_CachedClient::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $arg = array(
     'moe' => 5,
     'larry' => 6,

--- a/tests/xmlrpcextBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOffByDefault2.phpt
+++ b/tests/xmlrpcextBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOffByDefault2.phpt
@@ -29,7 +29,7 @@ $options = array(
     'cacheDebug' => true
 );
 
-$client = XML_RPC2_CachedClient::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_CachedClient::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $arg = array(
     'moe' => 5,
     'larry' => 6,

--- a/tests/xmlrpcextBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOnByDefault1.phpt
+++ b/tests/xmlrpcextBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOnByDefault1.phpt
@@ -28,7 +28,7 @@ $options = array(
     'cacheDebug' => true
 );
 
-$client = XML_RPC2_CachedClient::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_CachedClient::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $arg = array(
     'moe' => 5,
     'larry' => 6,

--- a/tests/xmlrpcextBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOnByDefault2.phpt
+++ b/tests/xmlrpcextBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOnByDefault2.phpt
@@ -27,7 +27,7 @@ $options = array(
     'cacheDebug' => true
 );
 
-$client = XML_RPC2_CachedClient::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_CachedClient::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $arg = array(
     'moe' => 5,
     'larry' => 6,

--- a/tests/xmlrpcextBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOnByDefault3.phpt
+++ b/tests/xmlrpcextBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOnByDefault3.phpt
@@ -33,7 +33,7 @@ $options = array(
     'cacheDebug' => true
 );
 
-$client = XML_RPC2_CachedClient::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_CachedClient::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $arg = array(
     'moe' => 5,
     'larry' => 6,

--- a/tests/xmlrpcextBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOnByDefault4.phpt
+++ b/tests/xmlrpcextBackend/cachedClient/phpxmlrpcValidator1EasyStructTestCacheOnByDefault4.phpt
@@ -32,7 +32,7 @@ $options = array(
     'cacheDebug' => true
 );
 
-$client = XML_RPC2_CachedClient::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_CachedClient::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $arg = array(
     'moe' => 5,
     'larry' => 6,

--- a/tests/xmlrpcextBackend/client/phpxmlrpcValidator1ArrayOfStructsTest.phpt
+++ b/tests/xmlrpcextBackend/client/phpxmlrpcValidator1ArrayOfStructsTest.phpt
@@ -19,7 +19,7 @@ $options = array(
     'backend' => 'Xmlrpcext',
     'prefix' => 'validator1.'
 );
-$client = XML_RPC2_Client::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_Client::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $arg = array(
     array(
         'moe' => 5,

--- a/tests/xmlrpcextBackend/client/phpxmlrpcValidator1CountTheEntities.phpt
+++ b/tests/xmlrpcextBackend/client/phpxmlrpcValidator1CountTheEntities.phpt
@@ -19,7 +19,7 @@ $options = array(
     'backend' => 'Xmlrpcext',
     'prefix' => 'validator1.'
 );
-$client = XML_RPC2_Client::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_Client::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $string = "foo <<< bar '> && '' #fo>o \" bar";
 $result = $client->countTheEntities($string);
 var_dump($result['ctLeftAngleBrackets']);

--- a/tests/xmlrpcextBackend/client/phpxmlrpcValidator1EasyStructTest.phpt
+++ b/tests/xmlrpcextBackend/client/phpxmlrpcValidator1EasyStructTest.phpt
@@ -19,7 +19,7 @@ $options = array(
     'backend' => 'Xmlrpcext',
     'prefix' => 'validator1.'
 );
-$client = XML_RPC2_Client::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_Client::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $arg = array(
     'moe' => 5,
     'larry' => 6,

--- a/tests/xmlrpcextBackend/client/phpxmlrpcValidator1EchoStructTest.phpt
+++ b/tests/xmlrpcextBackend/client/phpxmlrpcValidator1EchoStructTest.phpt
@@ -19,7 +19,7 @@ $options = array(
     'backend' => 'Xmlrpcext',
     'prefix' => 'validator1.'
 );
-$client = XML_RPC2_Client::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_Client::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $arg = array(
     'moe' => 5,
     'larry' => 6,

--- a/tests/xmlrpcextBackend/client/phpxmlrpcValidator1ManyTypesTest.phpt
+++ b/tests/xmlrpcextBackend/client/phpxmlrpcValidator1ManyTypesTest.phpt
@@ -24,7 +24,7 @@ $options = array(
     'backend' => 'Xmlrpcext',
     'prefix' => 'validator1.'
 );
-$client = XML_RPC2_Client::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_Client::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $tmp = "20060116T19:14:03";
 $time = XML_RPC2_Value::createFromNative($tmp, 'datetime');
 $base64 = XML_RPC2_Value::createFromNative('foobar', 'base64');

--- a/tests/xmlrpcextBackend/client/phpxmlrpcValidator1ModerateSizeArrayCheck.phpt
+++ b/tests/xmlrpcextBackend/client/phpxmlrpcValidator1ModerateSizeArrayCheck.phpt
@@ -19,7 +19,7 @@ $options = array(
     'backend' => 'Xmlrpcext',
     'prefix' => 'validator1.'
 );
-$client = XML_RPC2_Client::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_Client::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $tmp = array('foo');
 for ($i = 0 ; $i<150 ; $i++) {
     $tmp[] = "bla bla bla";

--- a/tests/xmlrpcextBackend/client/phpxmlrpcValidator1NestedStructTest.phpt
+++ b/tests/xmlrpcextBackend/client/phpxmlrpcValidator1NestedStructTest.phpt
@@ -19,7 +19,7 @@ $options = array(
     'backend' => 'Xmlrpcext',
     'prefix' => 'validator1.'
 );
-$client = XML_RPC2_Client::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_Client::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 
 $year1999 = array(
     '04' => array()

--- a/tests/xmlrpcextBackend/client/phpxmlrpcValidator1SimpleStructReturnTest.phpt
+++ b/tests/xmlrpcextBackend/client/phpxmlrpcValidator1SimpleStructReturnTest.phpt
@@ -19,7 +19,7 @@ $options = array(
     'backend' => 'Xmlrpcext',
     'prefix' => 'validator1.'
 );
-$client = XML_RPC2_Client::create('http://phpxmlrpc.sourceforge.net/server.php', $options);
+$client = XML_RPC2_Client::create('https://gggeek.altervista.org/sw/xmlrpc/demo/server/server.php', $options);
 $result = $client->simpleStructReturnTest(13);
 var_dump($result['times10']);
 var_dump($result['times100']);

--- a/tests/xmlrpcextBackend/server/validator1ArrayOfStructsTest.phpt
+++ b/tests/xmlrpcextBackend/server/validator1ArrayOfStructsTest.phpt
@@ -22,7 +22,7 @@ class TestServer {
      */
     public static function arrayOfStructsTest($array) {
         $result = 0;
-        while (list(, $struct) = each($array)) {
+        foreach ($array as $struct) {
             if (isset($struct['curly'])) {
                 $result = $result + $struct['curly'];
             }

--- a/tests/xmlrpcextBackend/server/validator1NestedStructTest.phpt
+++ b/tests/xmlrpcextBackend/server/validator1NestedStructTest.phpt
@@ -23,11 +23,11 @@ class TestServer {
     public static function nestedStructTest($struct) {
         // just to avoir problems with numeric indexes...
         $struct2 = array();
-        while (list($key, $year) = each($struct)) {
+        foreach($struct as $key => $year) {
             if ($key=='2000') {
-                while (list($key2, $month) = each($year)) {
+                foreach($year as $key2 => $month) {
                     if ($key2=='04') {
-                        while (list($key3, $day) = each($month)) {
+                        foreach ($month as $key3 => $day) {
                             if ($key3=='01') {
                                 return $day['moe'] + $day['larry'] + $day['curly'];
                             }

--- a/tests/xmlrpcextBackend/server/validator1NestedStructTest.phpt
+++ b/tests/xmlrpcextBackend/server/validator1NestedStructTest.phpt
@@ -25,7 +25,7 @@ class TestServer {
         $struct2 = array();
         foreach($struct as $key => $year) {
             if ($key=='2000') {
-                foreach($year as $key2 => $month) {
+                foreach ($year as $key2 => $month) {
                     if ($key2=='04') {
                         foreach ($month as $key3 => $day) {
                             if ($key3=='01') {


### PR DESCRIPTION
If you checkout the tests in master there's a large number of failures. So while updating the use of each to foreach in PHP 8, I also went ahead and fixed the tests so that we could merge it with CI passing. I've annotated the reasons for the changes in the files changed tab.
