### PR TITLE
Fix error due to PHP 8.2 deprecating ${var} string interpolation

### DIFF
--- a/XML/RPC2/Backend/Php/Request.php
+++ b/XML/RPC2/Backend/Php/Request.php
@@ -135,7 +135,7 @@ class XML_RPC2_Backend_Php_Request
 
         $result = '<?xml version="1.0" encoding="' . $this->_encoding . '"?' . ">\n";
         $result .= "<methodCall>";
-        $result .= "<methodName>${methodName}</methodName>";
+        $result .= "<methodName>{$methodName}</methodName>";
         $result .= "<params>";
         foreach ($parameters as $parameter) {
             $result .= "<param><value>";
@@ -168,5 +168,3 @@ class XML_RPC2_Backend_Php_Request
         return $result;
     }
 }
-
-?>

--- a/XML/RPC2/Backend/Xmlrpcext/Client.php
+++ b/XML/RPC2/Backend/Xmlrpcext/Client.php
@@ -108,7 +108,11 @@ class XML_RPC2_Backend_Xmlrpcext_Client extends XML_RPC2_Client
         */
         if (is_array($result) && xmlrpc_is_fault($result)) {
             if ($this->debug) {
-                print "XML_RPC2_Exception_Fault(${result['faultString']}, ${result['faultCode']})";
+                printf(
+                    "XML_RPC2_Exception_Fault(%s, %s)",
+                    $result['faultString'],
+                    $result['faultCode']
+                );
             }
             throw new XML_RPC2_Exception_Fault($result['faultString'], $result['faultCode']);
         }
@@ -118,5 +122,3 @@ class XML_RPC2_Backend_Xmlrpcext_Client extends XML_RPC2_Client
         return $result;
     }
 }
-
-?>


### PR DESCRIPTION
To Test:
1. You can recreate the bug by going to the `/subscribe` page and entering in an email address. You should see an error state on the field and if you have the Network tab of the inspector open you will see an error response from the `email` endpoint. The order summary endpoint also appeared to fail.
2. Checkout this PR in `/so/packages/xml_rpc2/work-[name]` and then run `yarn start --symlinks=xml_rpc2` in your emrap working dir
3. Go through the checkout on the `/subscribe` page and you should no longer see those errors